### PR TITLE
feature-005 | Adding Validation Bearer in Documentation With Open Api

### DIFF
--- a/app/Http/Controllers/Api/CustomerController.php
+++ b/app/Http/Controllers/Api/CustomerController.php
@@ -28,6 +28,7 @@ class CustomerController extends Controller
       *     summary="Returns a list of customers",
       *     description="Returns a object of all customers",
       *     path="/api/v1/customers",
+      *     security={ {"bearer": {}} },
       *     @OA\Response(response="200", description="list of Customers"),
       * ),
       *
@@ -67,6 +68,7 @@ class CustomerController extends Controller
      *         required=true,
      *         @OA\Schema(type="string"),
      *     ),
+     *     security={ {"bearer": {}} },
      *     @OA\Response(response="200", description="One Customer"),
      * ),
      *sss
@@ -177,6 +179,7 @@ class CustomerController extends Controller
       *         required=false,
       *         @OA\Schema(type="string"),
       *     ),
+      *     security={ {"bearer": {}} },
       *     @OA\Response(response="200", description="update Customer"),
       * ),
       *
@@ -228,6 +231,7 @@ class CustomerController extends Controller
       *         required=true,
       *         @OA\Schema(type="string"),
       *     ),
+      *     security={ {"bearer": {}} },
       *     @OA\Response(response="200", description="delete Customer"),
       * ),
       *

--- a/app/Http/Controllers/Api/ProductController.php
+++ b/app/Http/Controllers/Api/ProductController.php
@@ -27,6 +27,7 @@ class ProductController extends Controller
       *     summary="Returns a list of products",
       *     description="Returns a object of all products",
       *     path="/api/v1/products",
+      *     security={ {"bearer": {}} },      
       *     @OA\Response(response="200", description="list of products"),
       * ),
       *
@@ -62,6 +63,7 @@ class ProductController extends Controller
       *         required=true,
       *         @OA\Schema(type="string"),
       *     ),
+      *     security={ {"bearer": {}} },
       *     @OA\Response(response="200", description="one product"),
       * ),
       *
@@ -132,6 +134,7 @@ class ProductController extends Controller
       *         required=false,
       *         @OA\Schema(type="string"),
       *     ),
+      *     security={ {"bearer": {}} },
       *     @OA\Response(response="200", description="update Product"),
       * ),
       *
@@ -188,6 +191,7 @@ class ProductController extends Controller
       *         required=true,
       *         @OA\Schema(type="string"),
       *     ),
+      *     security={ {"bearer": {}} },
       *     @OA\Response(response="200", description="return a product deleted"),
       * ),
       *
@@ -255,6 +259,7 @@ class ProductController extends Controller
       *         required=false,
       *         @OA\Schema(type="string"),
       *     ),
+      *     security={ {"bearer": {}} },
       *     @OA\Response(response="200", description="Create Product"),
       * ),
       *

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -11,12 +11,6 @@ use Illuminate\Routing\Controller as BaseController;
  *   version="1.0.0",
  *   title="Gestor De Pedidos"
  * )
-* @OA\SecurityScheme(
- *     type="apiKey",
- *     in="header",
- *     securityScheme="Bearer",
- *     name="Authorization"
- * )
  */
 
 class Controller extends BaseController

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -156,13 +156,15 @@ return [
                 /*
                  * Examples of Security schemes
                 */
-                /*
-                'api_key_security_example' => [ // Unique name of security
-                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
-                    'description' => 'A short description for security scheme',
-                    'name' => 'api_key', // The name of the header or query parameter to be used.
-                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                
+                'bearer' => [
+                    'type' => 'http',
+                    'description' => 'Authorization token obtained from logging in.',
+                    'name' => 'Authorization',
+                    'in' => 'header',
+                    'scheme' => 'bearer',
                 ],
+                /*
                 'oauth2_security_example' => [ // Unique name of security
                     'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
                     'description' => 'A short description for oauth2 security scheme.',
@@ -204,6 +206,7 @@ return [
                  * Examples of Securities
                 */
                 [
+                    'bearer' => []
                     /*
                     'oauth2_security_example' => [
                         'read',


### PR DESCRIPTION
With this task i solving problem with Authorization in Swagger documentation, i solved this problem adding a jwt Bearer Token validation in l5-swagger.config, and calling in the endpoints with the Authorization requested